### PR TITLE
Update metadata_template.yml: Drop MCMC propagation

### DIFF
--- a/inst/extdata/metadata_template.yml
+++ b/inst/extdata/metadata_template.yml
@@ -38,8 +38,8 @@ metadata:
       status: assimilates #options: absent, present, data_driven, propagates, assimilates
       complexity: 2 #How many models states need initial conditions
       propagation:
-        type: ensemble #How does your model propogate initial conditions (ensemble or MCMC is most common)
-        size: 2000. #number of ensemble or MCMC members
+        type: ensemble #How does your model propogate initial conditions ('ensemble' is most common)
+        size: 2000. #number of ensemble members
       #Leave everything below blank  UNLESS status = assimilates  
       assimilation:
         type: refit #description of assimilation method


### PR DESCRIPTION
template was suggesting that 'MCMC' was a valid propagation method, but this throws an error with validator and is not consistent with the standards doc.