### PR TITLE
speed up score_it function with parallelization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     DBI,
     RSQLite,
     dplyr,
-    tidyr
+    tidyr,
+    furrr
 RoxygenNote: 7.1.2
 Language: en-US
 Suggests: 

--- a/R/read_forecast.R
+++ b/R/read_forecast.R
@@ -17,7 +17,7 @@ read_forecast <- function(file_in,
   no_forecast <- FALSE
   if(any(vapply(c("[.]csv", "[.]csv\\.gz"), grepl, logical(1), file_in))){  
     # if file is csv zip file
-    out <- readr::read_csv(file_in, guess_max = 1e6, lazy = FALSE) 
+    out <- readr::read_csv(file_in, guess_max = 1e6, lazy = FALSE, show_col_types = FALSE) 
     if("ixodes_scapularis" %in% names(out) | "amblyomma_americanum" %in% names(out)){
       out <- out %>% 
         dplyr::mutate(siteID = plotID) %>% 

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -45,8 +45,36 @@ score <- function(forecast,
   
 }
 
-# guess_theme 
+## Teach crps to treat any NA observations as NA scores:
+scoring_crps_ensemble <- function(y, dat) {
+  tryCatch(scoringRules::crps_sample(y, dat),
+           error = function(e) NA_real_, finally = NA_real_)
+}
 
+scoring_crps_stat <- function(y, mean, sd) {
+  tryCatch(scoringRules::crps_norm(y, mean = mean, sd = sd),
+           error = function(e) NA_real_, finally = NA_real_)
+}
+
+## Teach crps to treat any NA observations as NA scores:
+scoring_logs_ensemble <- function(y, dat) {
+  tryCatch(scoringRules::logs_sample(y, dat),
+           error = function(e) NA_real_, finally = NA_real_)
+}
+
+scoring_logs_stat <- function(y, mean, sd) {
+  tryCatch(scoringRules::logs_norm(y, mean = mean, sd = sd),
+           error = function(e) NA_real_, finally = NA_real_)
+}
+
+
+## FIXME:
+
+## tidy data (drop extraneous columns, fix dates etc)
+## pivot targets
+## pivot forecasts
+## inner_join
+## score
 crps_logs_score <- function(forecast, 
                        target,
                        grouping_variables = c("siteID", "time"),
@@ -62,10 +90,11 @@ crps_logs_score <- function(forecast,
                                              "ixodes_scapularis",
                                              "amblyomma_americanum"),
                        reps_col = c("ensemble")){
+
+  variables <- c(grouping_variables, target_variables, "ensemble", "statistic")
   
 
-  ## drop extraneous columns && make grouping vars into chr ids (i.e. not dates)
-
+  ## drop extraneous columns
   if("ensemble" %in% colnames(forecast)){ 
     reps_col <- "ensemble"
     variables <- c(grouping_variables, target_variables, reps_col)
@@ -75,11 +104,10 @@ crps_logs_score <- function(forecast,
   }
   
   forecast <- forecast %>% dplyr::select(tidyselect::any_of(
-    c(variables, "forest_start_time", "horizon", "team", "theme")))
+    c(variables, "forecast_start_time", "horizon", "team", "theme")))
   target <- target %>% dplyr::select(tidyselect::any_of(variables))
   
   
-  ## there's not necessarily a column for theme
   is_ticks <- any(grepl("ixodes", colnames(target))) || any(grepl("amblyomma", colnames(target)))
   if(is_ticks){
     target <- target %>% 
@@ -88,33 +116,14 @@ crps_logs_score <- function(forecast,
       dplyr::mutate(time =  ISOweek::ISOweek2date(paste0(ISOweek::ISOweek(time), "-","1")))
   }
   
-  ## Teach crps to treat any NA observations as NA scores:
-  scoring_crps_ensemble <- function(y, dat) {
-    tryCatch(scoringRules::crps_sample(y, dat),
-             error = function(e) NA_real_, finally = NA_real_)
-  }
-  
-  scoring_crps_stat <- function(y, mean, sd) {
-    tryCatch(scoringRules::crps_norm(y, mean = mean, sd = sd),
-             error = function(e) NA_real_, finally = NA_real_)
-  }
-  
-  ## Teach crps to treat any NA observations as NA scores:
-  scoring_logs_ensemble <- function(y, dat) {
-    tryCatch(scoringRules::logs_sample(y, dat),
-             error = function(e) NA_real_, finally = NA_real_)
-  }
-  
-  scoring_logs_stat <- function(y, mean, sd) {
-    tryCatch(scoringRules::logs_norm(y, mean = mean, sd = sd),
-             error = function(e) NA_real_, finally = NA_real_)
-  }
-  
-  ## Make tables into long format
+  ## Make tables into long format. 
+  ## FIXME  avoid repeatedly pivoting target data for each forecast
   target_long <- target %>% 
     tidyr::pivot_longer(tidyselect::any_of(target_variables), 
                  names_to = "target", 
                  values_to = "observed")
+  
+  
   forecast_long <- forecast %>% 
     tidyr::pivot_longer(tidyselect::any_of(target_variables), 
                  names_to = "target", 
@@ -123,7 +132,8 @@ crps_logs_score <- function(forecast,
   if(reps_col == "ensemble"){
     
     dplyr::inner_join(forecast_long, target_long, by = c(grouping_variables, "target"))  %>% 
-      dplyr::group_by(dplyr::across(tidyselect::any_of(c(grouping_variables, "target", "horizon", "team", "forest_start_time", "theme")))) %>% 
+      dplyr::group_by(dplyr::across(tidyselect::any_of(c(grouping_variables, 
+        "target", "horizon", "team", "forecast_start_time", "theme")))) %>% 
       dplyr::summarise(crps = scoring_crps_ensemble(observed[[1]], predicted),
                        logs = scoring_logs_ensemble(observed[[1]], predicted),
                        
@@ -135,7 +145,7 @@ crps_logs_score <- function(forecast,
       tidyr::pivot_wider(names_from = statistic, values_from = predicted) %>%
       dplyr::inner_join(target_long, by = c(grouping_variables, "target"))  %>% 
       dplyr::group_by(dplyr::across(dplyr::any_of(
-        c(grouping_variables, "target", "horizon", "team", "forest_start_time", "theme")))) %>% 
+        c(grouping_variables, "target", "horizon", "team", "forecast_start_time", "theme")))) %>% 
       dplyr::summarise(crps = scoring_crps_stat(observed[[1]], mean, sd),
                        logs = scoring_logs_stat(observed[[1]], mean, sd),
                 .groups = "drop")
@@ -171,9 +181,10 @@ score_it <- function(targets_file,
   ## Read in data and compute scores!
   target <- read_forecast(targets_file)
   score_files <- score_filenames(forecast_files)
-  forecasts <- lapply(forecast_files, read_forecast)
   
-  scores <- lapply(forecasts, 
+  forecasts <- furrr::future_map(forecast_files, read_forecast)
+  
+  scores <- furrr::future_map(forecasts, 
                    crps_logs_score, 
                    target = target,  
                    target_variables = target_variables, 


### PR DESCRIPTION
@rqthomas 
well haven't done anything clever yet to avoid re-computation, but realized `score_it` is easily parallelized.  (also suppressing print messages from readr really speeds up things when reading 1000s of files, so added that as well).  

Minor note as well, may be worth double-checking: I fixed what looks like a typo in `crps_log_score`: "forest_start_time" instead of "forecast_start_time".  

with parallel execution and the readr msg fix, I can parse and re-score the nearly 2K forecast files in a few minutes.  May still take a whack at cleaning up the logic in `crps_log_score`...  realizing it is something of a pity we didn't go with long form for forecasts so we need `pivot_longer` repeatedly....